### PR TITLE
FN: Feature - P5 Starfield

### DIFF
--- a/src/components/p5/Starfield.tsx
+++ b/src/components/p5/Starfield.tsx
@@ -1,0 +1,85 @@
+import React, {FC, useEffect, useRef, useCallback } from 'react';
+import styled from 'styled-components';
+//@ts-ignore
+import p5 from 'p5';
+
+interface Props {
+  width: number,
+  height: number
+};
+const Starfield: FC<Props> = ({width, height}) => {
+  const sketch_ref = useRef();
+
+  //@ts-ignore
+  const sketch = useCallback((p: p5) => {
+    let stars: {
+      id: number;
+      x: number;
+      y: number;
+      size: number;
+      opacity: number;
+      speed: number;
+      phase: number;
+    }[] = [];
+
+    p.setup = () => {
+      p.createCanvas(width,height);
+      p.noStroke();
+
+      stars = Array.from({ length: 2000 }, (_, i) => ({
+        id: i,
+        x: Math.random() * p.width,
+        y: Math.random() * p.height,
+        size: Math.random() * 2 + 0.5,
+        opacity: Math.random() * 0.5 + 0.1,
+        speed: Math.random() * 0.03 + 0.01,
+        phase: Math.random() * Math.PI * 2,
+      }));
+    };
+
+    p.draw = () => {
+      p.clear();
+
+      stars.forEach((star) => {
+        // pulse animation equivalent
+        const pulse = (Math.sin(p.frameCount * star.speed + star.phase) + 1) / 2;
+        const alpha = star.opacity * 255 * (0.4 + pulse * 0.6);
+
+        p.fill(255, alpha);
+        p.circle(
+          star.x,
+          star.y,
+          star.size + pulse * 1.5
+        );
+      });
+    };
+
+    p.windowResized = () => {
+      p.resizeCanvas(window.innerWidth, window.innerHeight);
+    };
+  }, []);
+
+    
+  useEffect(() => {
+    const p5canvas = new p5(sketch, sketch_ref.current);
+    return () => p5canvas.remove()
+  }, [sketch]);
+
+  return (
+    <Container>
+      {/* @ts-ignore */}
+      <div ref={sketch_ref} />
+    </Container>
+)
+};
+
+export default Starfield;
+
+const Container = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  pointer-events: none;
+  z-index: 1;
+`;

--- a/src/components/p5/Starfield.tsx
+++ b/src/components/p5/Starfield.tsx
@@ -1,5 +1,4 @@
 import React, {FC, useEffect, useRef, useCallback } from 'react';
-import { useDarkmode } from '../../Darkmode';
 
 import styled from 'styled-components';
 //@ts-ignore
@@ -40,7 +39,6 @@ const Starfield: FC<Props> = ({width, height}) => {
     };
 
     p.draw = () => {
-      
       p.clear();
       p.background(0);
 
@@ -61,9 +59,8 @@ const Starfield: FC<Props> = ({width, height}) => {
     p.windowResized = () => {
       p.resizeCanvas(window.innerWidth, window.innerHeight);
     };
-  }, []);
+  }, [width, height]);
 
-    
   useEffect(() => {
     const p5canvas = new p5(sketch, sketch_ref.current);
     return () => p5canvas.remove()

--- a/src/components/p5/Starfield.tsx
+++ b/src/components/p5/Starfield.tsx
@@ -1,4 +1,6 @@
 import React, {FC, useEffect, useRef, useCallback } from 'react';
+import { useDarkmode } from '../../Darkmode';
+
 import styled from 'styled-components';
 //@ts-ignore
 import p5 from 'p5';
@@ -23,14 +25,14 @@ const Starfield: FC<Props> = ({width, height}) => {
     }[] = [];
 
     p.setup = () => {
-      p.createCanvas(width,height);
+      p.createCanvas(width ? width : p.windowWidth, height ? height : p.windowHeight / 12 * 10);
       p.noStroke();
 
-      stars = Array.from({ length: 2000 }, (_, i) => ({
+      stars = Array.from({ length: 4000 }, (_, i) => ({
         id: i,
         x: Math.random() * p.width,
         y: Math.random() * p.height,
-        size: Math.random() * 2 + 0.5,
+        size: Math.random() * 3 + 0.5,
         opacity: Math.random() * 0.5 + 0.1,
         speed: Math.random() * 0.03 + 0.01,
         phase: Math.random() * Math.PI * 2,
@@ -38,7 +40,9 @@ const Starfield: FC<Props> = ({width, height}) => {
     };
 
     p.draw = () => {
+      
       p.clear();
+      p.background(0);
 
       stars.forEach((star) => {
         // pulse animation equivalent
@@ -70,16 +74,12 @@ const Starfield: FC<Props> = ({width, height}) => {
       {/* @ts-ignore */}
       <div ref={sketch_ref} />
     </Container>
-)
+  );
 };
 
 export default Starfield;
 
 const Container = styled.div`
-  position: fixed;
-  top: 0;
-  right: 0;
-  left: 0;
-  pointer-events: none;
   z-index: 1;
+  margin-top: 1vh;
 `;

--- a/src/routes/Gallery.tsx
+++ b/src/routes/Gallery.tsx
@@ -22,8 +22,8 @@ const P5_PLANE            = lazy(() => import('../components/p5/P5_PLANE'));
 const P5_LOADER           = lazy(() => import('../components/p5/P5_LOADER'));
 const P5_ANJA             = lazy(() => import('../components/p5/P5_ANJA'));
 const MondrianAnja        = lazy(() => import('../components/p5/MondrianAnja'));
-
 const P5_GEOSTORM         = lazy(() => import('../components/p5/P5_GEOSTORM'));
+const Starfield            = lazy(() => import('../components/p5/Starfield'));
 
 interface P5Props {
   strokeColor: number,
@@ -50,6 +50,7 @@ const Gallery: FC = () => {
     { component: P5_ANJA, title: 'ANJA', name: 'anja' },
     { component: MondrianAnja, title: 'ANJALEPH', name: 'anjaleph' },
     { component: P5_GEOSTORM, title: 'GEOSTORM', name: 'geostorm' },
+    { component: Starfield, title: 'STARFIELD', name: 'starfield' },
   ], []);
 
   useEffect(() => {


### PR DESCRIPTION
- Adds a new p5.js Starfield sketch with 4,000 randomly placed stars that pulse at independent speeds and phases on a black background.
- Registers STARFIELD in the Gallery alongside existing p5 projects (Geostorm, Anja, etc.) via lazy-loaded import.
- Tweaks star rendering in a follow-up commit: larger random circle sizes and a solid black background instead of a transparent canvas.

Implementation notes
- Each star has randomized size (0.5–3.5px), opacity, speed, and phase offset for varied twinkling.
- Pulse drives both alpha (0.4–1.0 of base opacity) and a slight size bump (+1.5px at peak).
- Canvas resizes with the window; defaults to full width and ~83% viewport height when no width/height props are passed.
- Follows the same React + p5 pattern as other gallery sketches (useCallback sketch, useEffect mount/cleanup).